### PR TITLE
Sort and clean prison finder data list

### DIFF
--- a/lists/prison-finder/bin/scrape_address.rb
+++ b/lists/prison-finder/bin/scrape_address.rb
@@ -1,14 +1,19 @@
 require 'nokogiri'
 
+def clean_name text
+	name = text.
+		to_s.
+		sub(/ (Prison|IRC) (contacts|information)/i,'').
+		sub(/Information for /i,'').
+		sub(/HMP and YOI /,'').
+		sub(/HMP /,'')
+end
+
 puts "prison\taddress-text\tpostcode"
 Dir.glob("./cache/*").each do |f| 
 	doc = Nokogiri::HTML(IO.read(f).gsub('div class="text"', 'p').gsub('<strong>Address','<p><strong>Address'))
 	if doc.at('title')
-		name = doc.at('title').
-			inner_text.
-			to_s.
-			sub(/ (Prison|IRC) (contacts|information)/i,'').
-			sub(/Information for /i,'')
+		name = clean_name(doc.at('title').inner_text)
 		print name
 	end
 	print "\t"

--- a/lists/prison-finder/bin/scrape_address.rb
+++ b/lists/prison-finder/bin/scrape_address.rb
@@ -82,10 +82,12 @@ end
 def ignore? name
   name == 'CEM Abertawe' ||
   name == 'CEM Caerdydd' ||
-  name == 'Usk/Prescoed'
+  name == 'Usk/Prescoed' ||
+  name == 'Usk'
 end
 
 puts "prison\taddress-text\tpostcode"
 name_address_postcodes.
   reject{|name, a, p| ignore?(name)}.
+  sort_by{|name, a, p| name}.
   each {|p| puts p.join("\t")}

--- a/lists/prison-finder/bin/scrape_address.rb
+++ b/lists/prison-finder/bin/scrape_address.rb
@@ -1,66 +1,91 @@
 require 'nokogiri'
 
 def clean_name text
-	name = text.
-		to_s.
-		sub(/ (Prison|IRC) (contacts|information)/i,'').
-		sub(/Information for /i,'').
-		sub(/HMP and YOI /,'').
-		sub(/HMP /,'')
+  name = text.
+    to_s.
+    sub(/ (Prison|IRC) (contacts|information)/i,'').
+    sub(/Information for /i,'').
+    sub(/HMP and YOI /,'').
+    sub(/HMP /,'')
+end
+
+def name doc
+  if doc.at('title')
+    clean_name(doc.at('title').inner_text)
+  end
+end
+
+def address_postcode name, doc
+  address = doc.search('p').
+    select{|x| x.inner_text[/[0-9][A-Z][A-Z]/] && !x.inner_text["ACCT"] }.
+    map do |x|
+      $pc = false
+      x.inner_html.
+        gsub("\r\n","\n").
+        gsub("<br>","\n").
+        gsub("<br />","\n").
+        squeeze("\n").
+        strip.
+        gsub("\n","|").
+        sub('addressing','').
+        sub(/(.*)?(Address|Cyfeiriad):?/i,"").
+        gsub("|","\n").
+        strip.
+        sub("</strong>","").
+        sub(':','').
+        split("\n").
+        map(&:strip).
+        map{|w| w.chomp(",")}.
+        map(&:strip).
+        delete_if do |w| 
+          opc = $pc
+          $pc = w[/[0-9][A-Z][A-Z]/].to_s.size > 0 unless $pc
+          opc || w.size == 0 
+        end
+  end.first
+  address = address.first.split(",") if address && address.size == 1
+  address = address.map do |x|
+    x.squeeze(' ').
+      sub('<!--?xmlnamespace prefix = st1 /?--> ','').
+      sub(/ \(Sat Nav.*/,'').
+      sub('     ','').
+      strip.
+      split(', ')
+  end.flatten if address
+  postcode = address.pop if address
+
+  if address.nil? && name == 'Humber'
+    address = ['Everthorpe', 'Brough']
+    postcode = 'HU15 2JZ'
+  end
+
+  address = address.nil? ? "" : address.join('|')
+
+  [address, postcode.to_s]
+end
+
+def doc file
+  Nokogiri::HTML IO.read(file).
+    gsub('div class="text"', 'p').
+    gsub('<strong>Address','<p><strong>Address')
+end
+
+def name_address_postcodes
+  Dir.glob("./cache/*").map do |file|
+    doc = doc(file)
+    name = name(doc)
+    address, postcode = address_postcode(name, doc)
+    [name, address, postcode]
+  end
+end
+
+def ignore? name
+  name == 'CEM Abertawe' ||
+  name == 'CEM Caerdydd' ||
+  name == 'Usk/Prescoed'
 end
 
 puts "prison\taddress-text\tpostcode"
-Dir.glob("./cache/*").each do |f| 
-	doc = Nokogiri::HTML(IO.read(f).gsub('div class="text"', 'p').gsub('<strong>Address','<p><strong>Address'))
-	if doc.at('title')
-		name = clean_name(doc.at('title').inner_text)
-		print name
-	end
-	print "\t"
-	
-	address = doc.search('p').
-		select{|x| x.inner_text[/[0-9][A-Z][A-Z]/] && !x.inner_text["ACCT"] }.
-		map do |x| 
-			$pc = false
-			x.inner_html.
-				gsub("\r\n","\n").
-				gsub("<br>","\n").
-				gsub("<br />","\n").
-				squeeze("\n").
-				strip.
-				gsub("\n","|").
-				sub('addressing','').
-				sub(/(.*)?(Address|Cyfeiriad):?/i,"").
-				gsub("|","\n").
-				strip.
-				sub("</strong>","").
-				sub(':','').
-				split("\n").
-				map(&:strip).
-				map{|w| w.chomp(",")}.
-				map(&:strip).
-				delete_if do |w| 
-					opc = $pc
-					$pc = w[/[0-9][A-Z][A-Z]/].to_s.size > 0 unless $pc
-					opc || w.size == 0 
-				end
-	end.first
-	address = address.first.split(",") if address && address.size == 1
-	address = address.map do |x|
-		x.squeeze(' ').
-			sub('<!--?xmlnamespace prefix = st1 /?--> ','').
-			sub(/ \(Sat Nav.*/,'').
-			sub('     ','').
-			strip.
-			split(', ')
-	end.flatten if address
-	postcode = address.pop if address
-
-	if address.nil? && name == 'Humber'
-		address = ['Everthorpe', 'Brough']
-		postcode = 'HU15 2JZ'
-	end
-	print address.nil? ? "" : address.join('|')
-	print "\t"
-	puts postcode.to_s
-end
+name_address_postcodes.
+  reject{|name, a, p| ignore?(name)}.
+  each {|p| puts p.join("\t")}

--- a/lists/prison-finder/prison-address-text.tsv
+++ b/lists/prison-finder/prison-address-text.tsv
@@ -54,8 +54,8 @@ Hewell	Hewell Lane|Redditch|Worcestershire	B97 6QS
 High Down		SM2 5PJ
 Highpoint	Stradishall|Newmarket|Suffolk	CB8 9YG
 Hindley	HM Prison Hindley|Gibson Street|Bickershaw|Wigan	WN2 5TH
-HMP Oakwood	Oak Road|Featherstone|West Midlands	WV10 7QD
-HMP and YOI Hollesley Bay	Woodbridge|Suffolk	IP12 3JW
+Oakwood	Oak Road|Featherstone|West Midlands	WV10 7QD
+Hollesley Bay	Woodbridge|Suffolk	IP12 3JW
 Holme House	Holme House Road|Stockton on Tees	TS18 2QU
 Hull	Hedon Road|Hull	HU9 5LS
 Huntercombe	Nuffield|Henley-on-Thames|Oxfordshire	RG9 5SB
@@ -108,7 +108,7 @@ Styal	Wilmslow|Cheshire	SK9 4HR
 Sudbury	Ashbourne|Derbyshire	DE6 5HW
 Swansea	200 Oystermouth Road|Swansea	SA1 3SR
 Swinfen Hall	HMYOI Swinfen Hall|Swinfen Hall|Lichfield|Staffordshire	WS14 9QS
-HMP Thameside	Griffin Manor Way|Thamesmead|London 	SE28 0FJ
+Thameside	Griffin Manor Way|Thamesmead|London 	SE28 0FJ
 The Mount	Molyneaux Avenue|Bovingdon|Hemel Hempstead|Herts	HP3 0NZ
 Thorn Cross	Arley Road|Appleton Thorn|Warrington|Cheshire	WA4 4RL
 Usk/Prescoed (Prescoed)	Coed-y-Paen|Pontypool|Monmouthshire	NP4 0TB

--- a/lists/prison-finder/prison-address-text.tsv
+++ b/lists/prison-finder/prison-address-text.tsv
@@ -30,7 +30,6 @@ Durham	Old Elvet|Durham	DH1 3HU
 East Sutton Park	HMP/YOI East Sutton Park|Sutton Valence|Maidstone|Kent	ME17 3DF
 Eastwood Park	Falfield|Wotton-under-Edge|Glos	GL12 8DB
 Erlestoke	Erlestoke|Devizes|Wiltshire	SN10 5TU
-Humber	Everthorpe|Brough	HU15 2JZ
 Exeter	30 New North Road|Exeter	EX4 4EX
 Featherstone	New Road|Featherstone|Wolverhampton	WV10 7PU
 Feltham	Bedfont Road|Feltham|Middlesex	TW13 4ND
@@ -51,12 +50,11 @@ Hewell	Hewell Lane|Redditch|Worcestershire	B97 6QS
 High Down		SM2 5PJ
 Highpoint	Stradishall|Newmarket|Suffolk	CB8 9YG
 Hindley	HM Prison Hindley|Gibson Street|Bickershaw|Wigan	WN2 5TH
-Oakwood	Oak Road|Featherstone|West Midlands	WV10 7QD
 Hollesley Bay	Woodbridge|Suffolk	IP12 3JW
 Holme House	Holme House Road|Stockton on Tees	TS18 2QU
 Hull	Hedon Road|Hull	HU9 5LS
+Humber	Everthorpe|Brough	HU15 2JZ
 Huntercombe	Nuffield|Henley-on-Thames|Oxfordshire	RG9 5SB
-Usk	44 Stry Maryport|Brynbuga|Sir Fynwy	NP15 1XP
 Isis	HMP &amp; YOI Isis|Western Way|Thamesmead	SE28 0NZ
 Isle of Wight	HMP Isle of Wight|Albany House|Newport|Isle of Wight	PO30 5RS
 Kennet	HM Prison Kennet|Parkbourn|Maghull|Liverpool|Merseyside	L31 1HX
@@ -83,6 +81,7 @@ North Sea Camp	HMP North Sea Camp|Croppers Lane|Freiston|Boston|Lincs	PE22 0QX
 Northumberland	HMP Northumberland|Morpeth|Northumberland	NE65 9XG
 Norwich	The Governor|Knox Road|Norwich|Norfolk	NR1 4LU
 Nottingham	Perry Road|Sherwood|Nottingham	NG5 3AG
+Oakwood	Oak Road|Featherstone|West Midlands	WV10 7QD
 Onley	HMP Onley|Rugby|Warwickshire	CV23 8AP
 Parc	Heol Hopcyn John|Bridgend|South Wales	CF35 6AP
 Pentonville	HMP Pentonville|Caledonian Road|London	N7 8TT

--- a/lists/prison-finder/prison-address-text.tsv
+++ b/lists/prison-finder/prison-address-text.tsv
@@ -15,9 +15,6 @@ Buckley Hall	Buckley Hall Road|Rochdale|Lancashire	OL12 9DP
 Bullingdon	PO Box 50|Bicester|OXON	OX25 1PZ
 Bure	HMP Bure|Jaguar Drive|Badersfield|Norwich|Norfolk	NR10 5GB
 Cardiff	Knox Road|Cardiff	CF24 0UG
-CEM Abertawe	200 Heol Oystermouth|Abertawe	SA1 3SR
-CEM Caerdydd	    Carchar EM Caerdydd|Know Road|Caerdydd	CF24 0UG
-Usk/Prescoed	Coed-y-Paen|Pontypwl|Sir Fynwy	NP14 0TD
 Channings Wood	HMP Channings Wood|Denbury|Newton Abbot|Devon	TQ12 6DW
 Chelmsford	200 Springfield Road|Chelmsford|Essex	CM2 6LQ
 Coldingley	Shaftesbury Road|Bisley|Woking|Surrey	GU24 9EX


### PR DESCRIPTION
For prison finder data:
- Improve name normalisation.
- ignore duplicated prisons.
- Sort by prison name.