### PR TITLE
Add former prisons to discovery register data

### DIFF
--- a/data/discovery/prison/prisons.tsv
+++ b/data/discovery/prison/prisons.tsv
@@ -121,3 +121,30 @@ WC	Winchester	HMP/YOI Winchester		100062015988
 WH	Woodhill	HMP/YOI Woodhill		25006001		
 WS	Wormwood Scrubs	HMP/YOI Wormwood Scrubs		34020469		
 WM	Wymott	HMP/YOI Wymott		200004064883		
+AK	Acklington	HMP Acklington				2011-10-31
+AL	Albany	HMP Albany				2009-04
+AW	Ashwell	HMP Ashwell				2011
+BT	Blakenhurst	HMP Blakenhurst				2008-06-25
+BD	Blundeston	HMP Blundeston				2013-12
+BK	Brockhill	HMP Brockhill				2008-06-25
+BU	Bullwood Hall	HMP Bullwood Hall				2013-03-28
+CH	Camp Hill	HMP Camp Hill				2009-04
+CY	Canterbury	HMP Canterbury				2013-03-31
+CS	Castinglon	HMP Castinglon				2011-10-31
+DR	Dorchester	HMP Dorchester				2013-12
+NE	Edmunds Hill	HMP Edmunds Hill				2011-04
+EV	Everthorpe	HMP Everthorpe				2014-04
+GL	Gloucester	HMP Gloucester				2013
+HG	Hewell Grange	HMP Hewell Grange				2008-06-25
+HY	Holloway	HMP Holloway				2016-07
+PT	Kingston	HMP Kingston				2013-03-28
+LM	Latchmere House	HMP Latchmere House				2011-09
+LA	Lancaster	HMP Lancaster				2011
+NN	Northallerton	HMP Northallerton				2013-12
+PK	Parkhurst	HMP Parkhurst				2009-04
+RD	Reading	HMP Reading				2013-11
+SM	Shepton Mallet	HMP Shepton Mallet				2013-02-28
+SY	Shrewsbury	HMP Shrewsbury				2013-03
+WA	The Weare	HMP The Weare				2006
+WB	Wellingborough	HMP Wellingborough				2012-12-21
+WO	Wolds	HMP Wolds				2014-04

--- a/data/discovery/prison/prisons.tsv
+++ b/data/discovery/prison/prisons.tsv
@@ -79,7 +79,7 @@ MD	Moorland	HMP/YOI Moorland		100051984633
 MH	Morton Hall	HMIRC Morton Hall (IRC)		10006531346		
 NH	New Hall	HMP/YOI New Hall		63141057		
 NS	North Sea Camp	HMP North Sea Camp		100032166609		
-AK	Northumberland	HMP Northumberland	company:00842846	10024651947		
+NL	Northumberland	HMP Northumberland	company:00842846	10024651947		
 NW	Norwich	HMP/YOI Norwich		10009434824		
 NM	Nottingham	HMP/YOI Nottingham		200001412499		
 OW	Oakwood	HMP Oakwood	company:00390328	10090090220		
@@ -103,7 +103,7 @@ SU	Sudbury	HMP Sudbury		10070076922
 SL	Swaleside	HMP Swaleside		100062087838		
 SW	Swansea	HMP/YOI Swansea		100100986762		
 SN	Swinfen Hall	HMP/YOI Swinfen Hall		10013212207		
-TH	Thameside	HMP/YOI Thameside	company:07279250	10010227695		
+TS	Thameside	HMP/YOI Thameside	company:07279250	10010227695		
 MT	The Mount	HMP The Mount		200004050582		
 VE	The Verne	HMIRC The Verne (IRC)		10070565745		
 TC	Thorn Cross	HMP/YOI Thorn Cross		200000978972		

--- a/lists/addresses/lib/load_data.rb
+++ b/lists/addresses/lib/load_data.rb
@@ -30,6 +30,10 @@ module LoadData
       remove_jointly_managed(prisons)
     end
 
+    def former_prisons
+      Morph.from_tsv read('../../former-prisons/prisons.tsv'), :former_prison
+    end
+
     def jointly_managed_prison_second_location
       prisons = Morph.from_tsv read('../../prison-finder/prison-address-text.tsv'), :prison
       prisons.select do |prison|

--- a/lists/addresses/lib/matcher.rb
+++ b/lists/addresses/lib/matcher.rb
@@ -86,9 +86,9 @@ module Matcher
              # On 31 October 2011 HM Prison Acklington merged with
              # HM Prison Castington to form HMP Northumberland
              when 'Northumberland'
-               'ACKLINGTON'
+               return 'NL'
              when 'Thameside'
-               return 'TH'
+               return 'TS'
              when 'The Mount'
                'MOUNT'
              when 'Usk/Prescoed (Prescoed)'

--- a/lists/addresses/lib/prison_data.rb
+++ b/lists/addresses/lib/prison_data.rb
@@ -7,8 +7,8 @@ require_relative 'matcher'
 require_relative 'write_data'
 
 codes = LoadData.laa_codes ; nil
-nomis_codes = LoadData.nomis_codes ; nil
 prisons = LoadData.prison_finder_prisons ; nil
+former_prisons = LoadData.former_prisons ; nil
 jointly_managed_prison_second_location = LoadData.jointly_managed_prison_second_location ; nil
 official_names = LoadData.prison_map_prisons ; nil
 contracted_out = LoadData.contracted_out_prisons ; nil
@@ -33,5 +33,17 @@ prisons.sort_by{|p| Matcher.massage_name(p.prison)}.each do |prison|
     address,
     nil,
     end_date
+  ].join("\t")
+end
+
+former_prisons.each do |prison|
+  puts [
+    prison.prison,
+    prison.name,
+    prison.official_name,
+    nil,
+    nil,
+    nil,
+    prison.end_date
   ].join("\t")
 end

--- a/lists/addresses/lib/prison_data.rb
+++ b/lists/addresses/lib/prison_data.rb
@@ -20,14 +20,14 @@ prisons.sort_by{|p| Matcher.massage_name(p.prison)}.each do |prison|
   name = prison.prison
   address = Matcher.address_uprn(prison, addresses)
   official_name = Matcher.match_official_name(name, official_names)
-  name = Matcher.short_name(name)
-  end_date = Matcher.end_date(name)
-  code = Matcher.match_code(name, codes)
+  short_name = Matcher.short_name(name)
+  end_date = Matcher.end_date(short_name)
+  code = Matcher.match_code(short_name, codes)
   binding.pry if code.blank?
-  company_number = Matcher.company_number(name, contracted_out)
+  company_number = Matcher.company_number(short_name, contracted_out)
   puts [
     code,
-    name,
+    short_name,
     official_name,
     company_number,
     address,

--- a/lists/former-prisons/prisons.tsv
+++ b/lists/former-prisons/prisons.tsv
@@ -1,0 +1,28 @@
+prison	nomis	name	official-name	start-date	end-date
+AK	AKI	Acklington	HMP Acklington		2011-10-31
+AL	ALI	Albany	HMP Albany		2009-04
+AW	AWI	Ashwell	HMP Ashwell		2011
+BT	BTI	Blakenhurst	HMP Blakenhurst		2008-06-25
+BD	BDI	Blundeston	HMP Blundeston		2013-12
+BK	BKI	Brockhill	HMP Brockhill		2008-06-25
+BU	BUI	Bullwood Hall	HMP Bullwood Hall		2013-03-28
+CH	CHI	Camp Hill	HMP Camp Hill		2009-04
+CY	CYI	Canterbury	HMP Canterbury		2013-03-31
+CS	CSI	Castinglon	HMP Castinglon		2011-10-31
+DR	DRI	Dorchester	HMP Dorchester		2013-12
+NE	NEI	Edmunds Hill	HMP Edmunds Hill		2011-04
+EV	EVI	Everthorpe	HMP Everthorpe		2014-04
+GL	GLI	Gloucester	HMP Gloucester		2013
+HG	HGI	Hewell Grange	HMP Hewell Grange		2008-06-25
+HY	HYI	Holloway	HMP Holloway		2016-07
+PT	PTI	Kingston	HMP Kingston		2013-03-28
+LM	LMI	Latchmere House	HMP Latchmere House		2011-09
+LA	LAI	Lancaster	HMP Lancaster		2011
+NN	NNI	Northallerton	HMP Northallerton		2013-12
+PK	PKI	Parkhurst	HMP Parkhurst		2009-04
+RD	RDI	Reading	HMP Reading		2013-11
+SM	SMI	Shepton Mallet	HMP Shepton Mallet		2013-02-28
+SY	SYI	Shrewsbury	HMP Shrewsbury		2013-03
+WA	WAI	The Weare	HMP The Weare		2006
+WB	WBI	Wellingborough	HMP Wellingborough		2012-12-21
+WO	WOI	Wolds	HMP Wolds		2014-04

--- a/lists/noms-codes/prison-codes.tsv
+++ b/lists/noms-codes/prison-codes.tsv
@@ -31,7 +31,7 @@ CD	CDI	Chelmsford
 CR		Colchester
 CL	CLI	Coldingley
 CK	CKI	Cookham Wood
-DA	CYI	Dartmoor
+DA	DAI	Dartmoor
 DT	DTI	Deerbolt
 DN	DNI	Doncaster
 DR	DRI	Dorchester


### PR DESCRIPTION
- Add manually created list of former prisons, including end-date fields.
- Add former prisons to discovery register data file.
- Correct NOMIS code for Dartmoor in list extracted from pdf.
- Change to NOMIS derived codes for Northumberland and Thameside.