### PR TITLE
Match former prison addresses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 target: data/discovery/prison/prisons.tsv ../address-discovery-data/maps/prison.tsv
 
+../address-discovery-data-matching/maps/prison.tsv: Gemfile.lock
+	bundle exec ruby ./lists/addresses/lib/address_street_postcode_data_map.rb > $@
+
 ../address-discovery-data/maps/prison.tsv: Gemfile.lock
 	bundle exec ruby ./lists/addresses/lib/address_data_map.rb > $@
 

--- a/data/discovery/prison/prisons.tsv
+++ b/data/discovery/prison/prisons.tsv
@@ -128,7 +128,7 @@ BK	Brockhill	HMP Brockhill				2008-06-25
 BU	Bullwood Hall	HMP Bullwood Hall				2013-03-28
 CH	Camp Hill	HMP Camp Hill				2009-04
 CY	Canterbury	HMP Canterbury				2013-03-31
-CS	Castinglon	HMP Castinglon				2011-10-31
+CS	Castington	HMP Castington				2011-10-31
 DR	Dorchester	HMP Dorchester				2013-12
 DV	Dover	HMIRC Dover				2015
 NE	Edmunds Hill	HMP Edmunds Hill				2011-04

--- a/data/discovery/prison/prisons.tsv
+++ b/data/discovery/prison/prisons.tsv
@@ -23,7 +23,6 @@ DA	Dartmoor	HMP Dartmoor		10001330266
 DT	Deerbolt	HMYOI Deerbolt		10070413833		
 DN	Doncaster	HMP/YOI Doncaster	company:00242246	100052207601		
 DG	Dovegate	HMP Dovegate	company:03471077	10008039764		
-DV	Dover			10034883299		2015
 DW	Downview	HMP/YOI Downview		68136669		
 DH	Drake Hall	HMP/YOI Drake Hall		10002088530		
 DM	Durham	HMP/YOI Durham		100110738556		
@@ -44,7 +43,6 @@ GT	Gartree	HMP Gartree		100030489952
 GP	Glen Parva	HMP/YOI Glen Parva		10010147357		
 GN	Grendon/Spring Hill	HMP Grendon/Spring Hill		766293688		
 GM	Guys Marsh	HMP Guys Marsh		10013217671		
-HR	Haslar			37032487		2015
 HD	Hatfield	HMP/YOI Hatfield		100050785306		
 HV	Haverigg	HMP Haverigg		100110755872		
 HE	Hewell	HMP Hewell		100121267009		
@@ -132,9 +130,11 @@ CH	Camp Hill	HMP Camp Hill				2009-04
 CY	Canterbury	HMP Canterbury				2013-03-31
 CS	Castinglon	HMP Castinglon				2011-10-31
 DR	Dorchester	HMP Dorchester				2013-12
+DV	Dover	HMIRC Dover				2015
 NE	Edmunds Hill	HMP Edmunds Hill				2011-04
 EV	Everthorpe	HMP Everthorpe				2014-04
 GL	Gloucester	HMP Gloucester				2013
+HR	Haslar	HMIRC Haslar				2015
 HG	Hewell Grange	HMP Hewell Grange				2008-06-25
 HY	Holloway	HMP Holloway				2016-07
 PT	Kingston	HMP Kingston				2013-03-28

--- a/lists/addresses/lib/address_data_map.rb
+++ b/lists/addresses/lib/address_data_map.rb
@@ -5,20 +5,28 @@ require_relative 'load_data'
 require_relative 'matcher'
 
 codes = LoadData.laa_codes ; nil
-nomis_codes = LoadData.nomis_codes ; nil
 prisons = LoadData.prison_finder_prisons ; nil
+former_prisons = LoadData.former_prisons ; nil
 jointly_managed_prison_second_location = LoadData.jointly_managed_prison_second_location ; nil
 addresses = LoadData.addresses ; nil
 
-puts %w[prison address addresses].join("\t")
+puts %w[prison address].join("\t")
 prisons.each do |prison|
   name = prison.prison
-  address = Matcher.address_uprn(prison, addresses)
+  address = Matcher.address_uprn(name, prison, addresses)
   all_addresses = Matcher.all_addresses(prison, prisons, addresses, jointly_managed_prison_second_location)
   code = Matcher.match_code(name, codes)
   puts [
     code,
     address,
-    all_addresses
+    # all_addresses
+  ].join("\t") if address
+end
+former_prisons.each do |prison|
+  address = Matcher.address_uprn(prison.name, prison, addresses)
+  code = prison.prison
+  puts [
+    code,
+    address
   ].join("\t") if address
 end

--- a/lists/addresses/lib/address_street_postcode_data_map.rb
+++ b/lists/addresses/lib/address_street_postcode_data_map.rb
@@ -1,0 +1,33 @@
+require 'pry'
+require_relative 'prison'
+require_relative 'address'
+require_relative 'load_data'
+require_relative 'matcher'
+
+codes = LoadData.laa_codes ; nil
+prisons = LoadData.prison_finder_prisons ; nil
+former_prisons = LoadData.former_prisons ; nil
+addresses = LoadData.addresses ; nil
+
+puts (%w[prison prison-name address] + addresses.first.morph_attributes.keys).join("\t")
+prisons.each do |prison|
+  name = prison.prison
+  address = Matcher.address_uprn(name, prison, addresses)
+  code = Matcher.match_code(name, codes)
+  short_name = Matcher.short_name(name)
+  puts ([
+    code,
+    short_name,
+    address
+  ] + addresses.detect{|a| a.key == address}.morph_attributes.values ).join("\t") if address
+end
+former_prisons.each do |prison|
+  address = Matcher.address_uprn(prison.name, prison, addresses)
+  code = prison.prison
+  short_name = Matcher.short_name(prison.name)
+  puts ([
+    code,
+    short_name,
+    address
+  ] + addresses.detect{|a| a.key == address}.morph_attributes.values ).join("\t") if address
+end

--- a/lists/addresses/lib/load_data.rb
+++ b/lists/addresses/lib/load_data.rb
@@ -38,7 +38,7 @@ module LoadData
     end
 
     def former_prisons
-      Morph.from_tsv read('../../former-prisons/prisons.tsv'), :former_prison
+      Morph.from_tsv read('../../former-prisons/prisons.tsv'), :prison
     end
 
     def jointly_managed_prison_second_location

--- a/lists/addresses/lib/load_data.rb
+++ b/lists/addresses/lib/load_data.rb
@@ -15,6 +15,12 @@ module LoadData
       end
     end
 
+    def remove_closed_prisons prisons
+      prisons.reject do |prison|
+        ['Haslar Immigration Removal Centre','Dover Immigration Removal Centre'].include?(prison.prison)
+      end
+    end
+
     def laa_codes
       codes = Morph.from_tsv read('../../legal-aid-agency/prison-codes.tsv'), :code
       codes.each {|x| x.code = x.code[0..1]}
@@ -27,7 +33,8 @@ module LoadData
 
     def prison_finder_prisons
       prisons = Morph.from_tsv read('../../prison-finder/prison-address-text.tsv'), :prison
-      remove_jointly_managed(prisons)
+      prisons = remove_jointly_managed(prisons)
+      remove_closed_prisons(prisons)
     end
 
     def former_prisons

--- a/lists/addresses/lib/load_data.rb
+++ b/lists/addresses/lib/load_data.rb
@@ -59,7 +59,7 @@ module LoadData
     end
 
     def addresses
-      Morph.from_csv(read('../address_street_postcode.csv'), :address)
+      Morph.from_csv(read('../../../../address-discovery-data-matching/lists/prison-data/prison-address-street-postcode.csv'), :address)
     end
   end
 end

--- a/lists/addresses/lib/matcher.rb
+++ b/lists/addresses/lib/matcher.rb
@@ -7,6 +7,9 @@ module Matcher
     def score name, address_parts, postcode, address
       score = 0.0
       score += 1.3 if address.name.to_s.include?(name) || address.name_cy.to_s.include?(name)
+      if name == 'LANCASTER' && address.name.to_s.include?('LANCASTER FARMS')
+        score -= 5
+      end
       if name_include?('PRISON', address)
         score += 0.1
       else
@@ -17,6 +20,7 @@ module Matcher
         name_include?('VISITORS CENTRE', address) ||
         name_include?('PHARMACY', address) ||
         name_include?('BUS SHELTER', address) ||
+        name_include?('CAR PARK', address) ||
         name_include?('ELECTRICITY SUBSTATION', address)
         score -= 3.0
       end
@@ -151,8 +155,7 @@ module Matcher
       end
     end
 
-    def address_uprn prison, address_list
-      name = prison.prison
+    def address_uprn name, prison, address_list
       address_parts = prison.address_parts
       postcode = prison.postcode
       match = match_address(name, address_parts, postcode, address_list)
@@ -169,11 +172,11 @@ module Matcher
     def other_addresses other_location, address, prisons, addresses
       prison = prisons.detect{|x| x.prison == other_location}
       binding.pry if prison.nil?
-      [address, address_uprn(prison, addresses)]
+      [address, address_uprn(prison.prison, prison, addresses)]
     end
 
     def all_addresses prison, prisons, addresses, jointly_managed_prison_second_location
-      address = address_uprn(prison, addresses)
+      address = address_uprn(prison.prison, prison, addresses)
       case prison.prison
       when 'Usk/Prescoed (Usk)'
         other_addresses('Usk/Prescoed (Prescoed)', address, jointly_managed_prison_second_location, addresses).join(";")

--- a/lists/addresses/lib/prison_data.rb
+++ b/lists/addresses/lib/prison_data.rb
@@ -18,7 +18,7 @@ puts %w[prison name official-name organisation address start-date end-date].join
 
 prisons.sort_by{|p| Matcher.massage_name(p.prison)}.each do |prison|
   name = prison.prison
-  address = Matcher.address_uprn(prison, addresses)
+  address = Matcher.address_uprn(name, prison, addresses)
   official_name = Matcher.match_official_name(name, official_names)
   short_name = Matcher.short_name(name)
   end_date = Matcher.end_date(short_name)

--- a/lists/former-prisons/prisons.tsv
+++ b/lists/former-prisons/prisons.tsv
@@ -1,30 +1,30 @@
-prison	nomis	name	official-name	start-date	end-date
-AK	AKI	Acklington	HMP Acklington		2011-10-31
-AL	ALI	Albany	HMP Albany		2009-04
-AW	AWI	Ashwell	HMP Ashwell		2011
-BT	BTI	Blakenhurst	HMP Blakenhurst		2008-06-25
-BD	BDI	Blundeston	HMP Blundeston		2013-12
-BK	BKI	Brockhill	HMP Brockhill		2008-06-25
-BU	BUI	Bullwood Hall	HMP Bullwood Hall		2013-03-28
-CH	CHI	Camp Hill	HMP Camp Hill		2009-04
-CY	CYI	Canterbury	HMP Canterbury		2013-03-31
-CS	CSI	Castington	HMP Castington		2011-10-31
-DR	DRI	Dorchester	HMP Dorchester		2013-12
-DV	DVI	Dover	HMIRC Dover		2015
-NE	NEI	Edmunds Hill	HMP Edmunds Hill		2011-04
-EV	EVI	Everthorpe	HMP Everthorpe		2014-04
-GL	GLI	Gloucester	HMP Gloucester		2013
-HR	HRI	Haslar	HMIRC Haslar		2015
-HG	HGI	Hewell Grange	HMP Hewell Grange		2008-06-25
-HY	HYI	Holloway	HMP Holloway		2016-07
-PT	PTI	Kingston	HMP Kingston		2013-03-28
-LM	LMI	Latchmere House	HMP Latchmere House		2011-09
-LA	LAI	Lancaster	HMP Lancaster		2011
-NN	NNI	Northallerton	HMP Northallerton		2013-12
-PK	PKI	Parkhurst	HMP Parkhurst		2009-04
-RD	RDI	Reading	HMP Reading		2013-11
-SM	SMI	Shepton Mallet	HMP Shepton Mallet		2013-02-28
-SY	SYI	Shrewsbury	HMP Shrewsbury		2013-03
-WA	WAI	The Weare	HMP The Weare		2006
-WB	WBI	Wellingborough	HMP Wellingborough		2012-12-21
-WO	WOI	Wolds	HMP Wolds		2014-04
+prison	nomis	name	official-name	start-date	end-date	address-text	postcode
+AK	AKI	Acklington	HMP Acklington		2011-10-31	HMP Acklington|Acklington|Morpeth|Northumberland	NE65 9XF
+AL	ALI	Albany	HMP Albany		2009-04	HMP Albany|55 Parkhurst Road|Newport|Isle of Wight	PO30 5RS
+AW	AWI	Ashwell	HMP Ashwell		2011	HMP Ashwell|Oakham|Rutland	LE15 7LF
+BT	BTI	Blakenhurst	HMP Blakenhurst		2008-06-25	HMP Blakenhurst|Hewell Lane|Redditch	B97 6QS
+BD	BDI	Blundeston	HMP Blundeston		2013-12	HMP Blundeston|Lowestoft|Suffolk	NR32 5BG
+BK	BKI	Brockhill	HMP Brockhill		2008-06-25	HMP Brockhill|Hewell Lane|Redditch|Worcestershire	B97 6QS
+BU	BUI	Bullwood Hall	HMP Bullwood Hall		2013-03-28	HMP/YOI BULLWOOD HALL|High Road|Hockley	SS5 4TE
+CH	CHI	Camp Hill	HMP Camp Hill		2009-04	HMP Camp Hill|Newport|Isle of Wight	PO30 5PB
+CY	CYI	Canterbury	HMP Canterbury		2013-03-31	HMP Canterbury|46 Longport|Canterbury|Kent	CT1 1PJ
+CS	CSI	Castington	HMP Castington		2011-10-31	HMP/YOI CASTINGTON|Morpeth|Northumberland	NE65 9XG
+DR	DRI	Dorchester	HMP Dorchester		2013-12	HMP Dorchester|North Square|Dorchester|Dorset	DT1 1JD
+DV	DVI	Dover	HMIRC Dover		2015	The Citadel|Western Heights|Dover|Kent	CT17 9DR
+NE	NEI	Edmunds Hill	HMP Edmunds Hill		2011-04	Stradishall|Newmarket|Suffolk	CB8 9YN
+EV	EVI	Everthorpe	HMP Everthorpe		2014-04	HMP Everthorpe|Beck Road|Everthorpe Brough|East Yorkshire	HU15 1RB
+GL	GLI	Gloucester	HMP Gloucester		2013	HMP/YOI GLOUCESTER|Barrack Square|Gloucester	GL1 2JN
+HR	HRI	Haslar	HMIRC Haslar		2015	2 Dolphin Way|Gosport|Hampshire	PO12 2AW
+HG	HGI	Hewell Grange	HMP Hewell Grange		2008-06-25	HMP Hewell Grange, Redditch, Worcestershire	B97 6QQ
+HY	HYI	Holloway	HMP Holloway		2016-07	HMP/YOI HOLLOWAY|Parkhurst Road|London	N7 0NU
+PT	PTI	Kingston	HMP Kingston		2013-03-28	122 Milton Road|Portsmouth|Hampshire	PO3 6AS
+LM	LMI	Latchmere House	HMP Latchmere House		2011-09	Church Road|Ham Common|Richmond|Surrey	TW10 5HH
+LA	LAI	Lancaster	HMP Lancaster		2011	The Castle|LANCASTER|Lancashire	LA1 1YL
+NN	NNI	Northallerton	HMP Northallerton		2013-12	HMYOI NORTHALLERTON|15A East Road|Northallerton|North Yorkshire	DL6 1NW
+PK	PKI	Parkhurst	HMP Parkhurst		2009-04	Newport|Isle of Wight	PO30 5NX
+RD	RDI	Reading	HMP Reading		2013-11	HMP/YOI  READING|Forbury Road|Reading|Berkshire	RG1 3HY
+SM	SMI	Shepton Mallet	HMP Shepton Mallet		2013-02-28	Cornhill|Shepton Mallet|Somerset	BA4 5LU
+SY	SYI	Shrewsbury	HMP Shrewsbury		2013-03	The Dana|Shrewsbury|Shropshire	SY1 2HR
+WA	WAI	The Weare	HMP The Weare		2006	Rotherham Road|Castletown|Portland|Dorset	DT5 1PZ
+WB	WBI	Wellingborough	HMP Wellingborough		2012-12-21	Millers Park|Doddington Road|Wellingborough|Northamptonshire	NN8 2NH
+WO	WOI	Wolds	HMP Wolds		2014-04	Everthorpe|Brough|East Yorkshire	HU15 2JZ

--- a/lists/former-prisons/prisons.tsv
+++ b/lists/former-prisons/prisons.tsv
@@ -8,7 +8,7 @@ BK	BKI	Brockhill	HMP Brockhill		2008-06-25
 BU	BUI	Bullwood Hall	HMP Bullwood Hall		2013-03-28
 CH	CHI	Camp Hill	HMP Camp Hill		2009-04
 CY	CYI	Canterbury	HMP Canterbury		2013-03-31
-CS	CSI	Castinglon	HMP Castinglon		2011-10-31
+CS	CSI	Castington	HMP Castington		2011-10-31
 DR	DRI	Dorchester	HMP Dorchester		2013-12
 DV	DVI	Dover	HMIRC Dover		2015
 NE	NEI	Edmunds Hill	HMP Edmunds Hill		2011-04

--- a/lists/former-prisons/prisons.tsv
+++ b/lists/former-prisons/prisons.tsv
@@ -10,9 +10,11 @@ CH	CHI	Camp Hill	HMP Camp Hill		2009-04
 CY	CYI	Canterbury	HMP Canterbury		2013-03-31
 CS	CSI	Castinglon	HMP Castinglon		2011-10-31
 DR	DRI	Dorchester	HMP Dorchester		2013-12
+DV	DVI	Dover	HMIRC Dover		2015
 NE	NEI	Edmunds Hill	HMP Edmunds Hill		2011-04
 EV	EVI	Everthorpe	HMP Everthorpe		2014-04
 GL	GLI	Gloucester	HMP Gloucester		2013
+HR	HRI	Haslar	HMIRC Haslar		2015
 HG	HGI	Hewell Grange	HMP Hewell Grange		2008-06-25
 HY	HYI	Holloway	HMP Holloway		2016-07
 PT	PTI	Kingston	HMP Kingston		2013-03-28


### PR DESCRIPTION
- Add two closed IRC to former prisons list
- Fix spelling of former prison name
- Change location of potential prison address source file
- Add address-text and postcode fields to former prison list
- Include former prisons in address discovery data generation