### PR TITLE
Move long prison name to `name` field

### DIFF
--- a/data/discovery/prison/prisons.tsv
+++ b/data/discovery/prison/prisons.tsv
@@ -1,150 +1,150 @@
 prison	name	official-name	organisation	address	start-date	end-date
-AC	Altcourse	HMP/YOI Altcourse	company:02984969	38076557		
-AS	Ashfield	HMP Ashfield	company:03403669	640757		
-AG	Askham Grange	HMP/YOI Askham Grange		100052211414		
-AY	Aylesbury	HMYOI Aylesbury		766259071		
-BF	Bedford	HMP/YOI Bedford		100081206238		
-BA	Belmarsh	HMP/YOI Belmarsh		100023266926		
-BM	Birmingham	HMP Birmingham	company:00390328	100071434380		
-BH	Blantyre House	HMP Blantyre House		10000064793		
-BS	Brinsford	HMP/YOI Brinsford		200004529143		
-BL	Bristol	HMP/YOI Bristol		221691		
-BX	Brixton	HMP Brixton		200000487964		
-BZ	Bronzefield	HMP/YOI Bronzefield (F)	company:04334205	33043320		
-BC	Buckley Hall	HMP Buckley Hall		23107795		
-BN	Bullingdon	HMP/YOI Bullingdon		100120801929		
-BR	Bure	HMP Bure		10023452387		
-CF	Cardiff	HMP/YOI Cardiff		200002933741		
-CW	Channings Wood	HMP Channings Wood		10032952569		
-CD	Chelmsford	HMP/YOI Chelmsford		200004625000		
-CL	Coldingley	HMP Coldingley		200001339117		
-CK	Cookham Wood	HMYOI Cookham Wood		100062374701		
-DA	Dartmoor	HMP Dartmoor		10001330266		
-DT	Deerbolt	HMYOI Deerbolt		10070413833		
-DN	Doncaster	HMP/YOI Doncaster	company:00242246	100052207601		
-DG	Dovegate	HMP Dovegate	company:03471077	10008039764		
-DW	Downview	HMP/YOI Downview		68136669		
-DH	Drake Hall	HMP/YOI Drake Hall		10002088530		
-DM	Durham	HMP/YOI Durham		100110738556		
-ES	East Sutton Park	HMP/YOI East Sutton Park		10022897161		
-EW	Eastwood Park	HMP/YOI Eastwood Park		582216		
-EY	Elmley	HMP/YOI Elmley		100062087837		
-EE	Erlestoke	HMP Erlestoke		10000177465		
-EX	Exeter	HMP/YOI Exeter		100041142520		
-FS	Featherstone	HMP Featherstone		100032229278		
-FM	Feltham	HMYOI Feltham		100023398319		
-FD	Ford	HMP Ford		200002714169		
-FB	Forest Bank	HMP/YOI Forest Bank	company:03509050	100012692516		
-FH	Foston Hall	HMP/YOI Foston Hall		10000819194		
-FK	Frankland	HMP Frankland		10001009852		
-FN	Full Sutton	HMP Full Sutton		200000641988		
-GH	Garth	HMP Garth		200004064874		
-GT	Gartree	HMP Gartree		100030489952		
-GP	Glen Parva	HMP/YOI Glen Parva		10010147357		
-GN	Grendon/Spring Hill	HMP Grendon/Spring Hill		766293688		
-GM	Guys Marsh	HMP Guys Marsh		10013217671		
-HD	Hatfield	HMP/YOI Hatfield		100050785306		
-HV	Haverigg	HMP Haverigg		100110755872		
-HE	Hewell	HMP Hewell		100121267009		
-HO	High Down	HMP/YOI High Down		100062499824		
-HP	Highpoint	HMP Highpoint		10010693330		
-HI	Hindley	HMP/YOI Hindley		100012815264		
-HB	Hollesley Bay	HMP/YOI Hollesley Bay		10008620964		
-HH	Holme House	HMP/YOI Holme House		100110796240		
-HL	Hull	HMP/YOI Hull		21138448		
-HM	Humber	HMP Humber		200000644367		
-HC	Huntercombe	HMP Huntercombe (FNP)		100121308432		
-IS	Isis	HMP/YOI Isis				
-PK	Isle of Wight	HMP/YOI Isle of Wight		10003332444		
-KT	Kennet	HMP Kennet		41218084		
-KM	Kirkham	HMP Kirkham		100012390917		
-KV	Kirklevington Grange	HMP Kirklevington Grange		100110778426		
-LF	Lancaster Farms	HMP Lancaster Farms		200001339049		
-LE	Leeds	HMP Leeds		72079826		
-LC	Leicester	HMP Leicester		2465057785		
-LW	Lewes	HMP/YOI Lewes		100062273779		
-LY	Leyhill	HMP Leyhill		582486		
-LI	Lincoln	HMP/YOI Lincoln		235033467		
-LH	Lindholme	HMP Lindholme		10006712272		
-LT	Littlehey	HMP Littlehey		10000161141		
-LP	Liverpool	HMP Liverpool		38079136		
-LL	Long Lartin	HMP Long Lartin		10013943723		
-LN	Low Newton	HMP/YOI Low Newton		100110739224		
-LG	Lowdham Grange	HMP Lowdham Grange	company:03154430	10008170171		
-MS	Maidstone	HMP Maidstone (FNP)		200003717305		
-MR	Manchester	HMP/YOI Manchester		77232134		
-MD	Moorland	HMP/YOI Moorland		100051984633		
-MH	Morton Hall	HMIRC Morton Hall (IRC)		10006531346		
-NH	New Hall	HMP/YOI New Hall		63141057		
-NS	North Sea Camp	HMP North Sea Camp		100032166609		
-NL	Northumberland	HMP Northumberland	company:00842846	10024651947		
-NW	Norwich	HMP/YOI Norwich		10009434824		
-NM	Nottingham	HMP/YOI Nottingham		200001412499		
-OW	Oakwood	HMP Oakwood	company:00390328	10090090220		
-ON	Onley	HMP Onley		28013722		
-PR	Parc	HMP/YOI Parc (YP)	company:03045222	200002656535		
-PV	Pentonville	HMP/YOI Pentonville		5300014341		
-PB	Peterborough	HMP/YOI Peterborough (F)	company:04350276	10008051379		
-PD	Portland	HMP/YOI Portland		10070567623		
-PN	Preston	HMP/YOI Preston		100012746893		
-RN	Ranby	HMP Ranby		10013978351		
-RS	Risley	HMP Risley		100012381987		
-RC	Rochester	HMP/YOI Rochester		44010823		
-RH	Rye Hill	HMP Rye Hill	company:03682678	28042679		
-SD	Send	HMP/YOI Send		10007066161		
-SF	Stafford	HMP Stafford		200001335547		
-EH	Standford Hill	HMP Standford Hill		200002533135		
-SK	Stocken	HMP Stocken		10008626900		
-SH	Stoke Heath	HMP/YOI Stoke Heath		10013133936		
-ST	Styal	HMP/YOI Styal		100012881776		
-SU	Sudbury	HMP Sudbury		10070076922		
-SL	Swaleside	HMP Swaleside		100062087838		
-SW	Swansea	HMP/YOI Swansea		100100986762		
-SN	Swinfen Hall	HMP/YOI Swinfen Hall		10013212207		
-TS	Thameside	HMP/YOI Thameside	company:07279250	10010227695		
-MT	The Mount	HMP The Mount		200004050582		
-VE	The Verne	HMIRC The Verne (IRC)		10070565745		
-TC	Thorn Cross	HMP/YOI Thorn Cross		200000978972		
-UK	Usk/Prescoed	HMP Usk and HMP/YOI Prescoed		200000955803		
-WD	Wakefield	HMP Wakefield		63131104		
-WW	Wandsworth	HMP/YOI Wandsworth		121050999		
-WI	Warren Hill	HMP/YOI Warren Hill		10008620969		
-WL	Wayland	HMP Wayland		10011970324		
-WE	Wealstun	HMP Wealstun		72384891		
-WN	Werrington	HMYOI Werrington		200001581565		
-WY	Wetherby	HMYOI Wetherby		72555064		
-WT	Whatton	HMP Whatton		3040053432		
-WR	Whitemoor	HMP Whitemoor		100091516265		
-WC	Winchester	HMP/YOI Winchester		100062015988		
-WH	Woodhill	HMP/YOI Woodhill		25006001		
-WS	Wormwood Scrubs	HMP/YOI Wormwood Scrubs		34020469		
-WM	Wymott	HMP/YOI Wymott		200004064883		
-AK	Acklington	HMP Acklington		2920005642		2011-10-31
-AL	Albany	HMP Albany		10003332444		2009-04
-AW	Ashwell	HMP Ashwell		100030715098		2011
-BT	Blakenhurst	HMP Blakenhurst		100121267009		2008-06-25
-BD	Blundeston	HMP Blundeston		100091568382		2013-12
-BK	Brockhill	HMP Brockhill		100120586678		2008-06-25
-BU	Bullwood Hall	HMP Bullwood Hall		200000266767		2013-03-28
-CH	Camp Hill	HMP Camp Hill		10003316343		2009-04
-CY	Canterbury	HMP Canterbury				2013-03-31
-CS	Castington	HMP Castington		2920009030		2011-10-31
-DR	Dorchester	HMP Dorchester				2013-12
-DV	Dover	HMIRC Dover		10034883299		2015
-NE	Edmunds Hill	HMP Edmunds Hill		10023127022		2011-04
-EV	Everthorpe	HMP Everthorpe		200000644359		2014-04
-GL	Gloucester	HMP Gloucester		200004486808		2013
-HR	Haslar	HMIRC Haslar		37032487		2015
-HG	Hewell Grange	HMP Hewell Grange				2008-06-25
-HY	Holloway	HMP Holloway		5300071065		2016-07
-PT	Kingston	HMP Kingston		1775056170		2013-03-28
-LM	Latchmere House	HMP Latchmere House				2011-09
-LA	Lancaster	HMP Lancaster				2011
-NN	Northallerton	HMP Northallerton		100050366776		2013-12
-PK	Parkhurst	HMP Parkhurst		10003332443		2009-04
-RD	Reading	HMP Reading				2013-11
-SM	Shepton Mallet	HMP Shepton Mallet		250022303		2013-02-28
-SY	Shrewsbury	HMP Shrewsbury		100071531042		2013-03
-WA	The Weare	HMP The Weare		10070569459		2006
-WB	Wellingborough	HMP Wellingborough		10023681392		2012-12-21
-WO	Wolds	HMP Wolds				2014-04
+AC	HMP/YOI Altcourse		company:02984969	38076557		
+AS	HMP Ashfield		company:03403669	640757		
+AG	HMP/YOI Askham Grange			100052211414		
+AY	HMYOI Aylesbury			766259071		
+BF	HMP/YOI Bedford			100081206238		
+BA	HMP/YOI Belmarsh			100023266926		
+BM	HMP Birmingham		company:00390328	100071434380		
+BH	HMP Blantyre House			10000064793		
+BS	HMP/YOI Brinsford			200004529143		
+BL	HMP/YOI Bristol			221691		
+BX	HMP Brixton			200000487964		
+BZ	HMP/YOI Bronzefield (F)		company:04334205	33043320		
+BC	HMP Buckley Hall			23107795		
+BN	HMP/YOI Bullingdon			100120801929		
+BR	HMP Bure			10023452387		
+CF	HMP/YOI Cardiff			200002933741		
+CW	HMP Channings Wood			10032952569		
+CD	HMP/YOI Chelmsford			200004625000		
+CL	HMP Coldingley			200001339117		
+CK	HMYOI Cookham Wood			100062374701		
+DA	HMP Dartmoor			10001330266		
+DT	HMYOI Deerbolt			10070413833		
+DN	HMP/YOI Doncaster		company:00242246	100052207601		
+DG	HMP Dovegate		company:03471077	10008039764		
+DW	HMP/YOI Downview			68136669		
+DH	HMP/YOI Drake Hall			10002088530		
+DM	HMP/YOI Durham			100110738556		
+ES	HMP/YOI East Sutton Park			10022897161		
+EW	HMP/YOI Eastwood Park			582216		
+EY	HMP/YOI Elmley			100062087837		
+EE	HMP Erlestoke			10000177465		
+EX	HMP/YOI Exeter			100041142520		
+FS	HMP Featherstone			100032229278		
+FM	HMYOI Feltham			100023398319		
+FD	HMP Ford			200002714169		
+FB	HMP/YOI Forest Bank		company:03509050	100012692516		
+FH	HMP/YOI Foston Hall			10000819194		
+FK	HMP Frankland			10001009852		
+FN	HMP Full Sutton			200000641988		
+GH	HMP Garth			200004064874		
+GT	HMP Gartree			100030489952		
+GP	HMP/YOI Glen Parva			10010147357		
+GN	HMP Grendon/Spring Hill			766293688		
+GM	HMP Guys Marsh			10013217671		
+HD	HMP/YOI Hatfield			100050785306		
+HV	HMP Haverigg			100110755872		
+HE	HMP Hewell			100121267009		
+HO	HMP/YOI High Down			100062499824		
+HP	HMP Highpoint			10010693330		
+HI	HMP/YOI Hindley			100012815264		
+HB	HMP/YOI Hollesley Bay			10008620964		
+HH	HMP/YOI Holme House			100110796240		
+HL	HMP/YOI Hull			21138448		
+HM	HMP Humber			200000644367		
+HC	HMP Huntercombe (FNP)			100121308432		
+IS	HMP/YOI Isis					
+PK	HMP/YOI Isle of Wight			10003332444		
+KT	HMP Kennet			41218084		
+KM	HMP Kirkham			100012390917		
+KV	HMP Kirklevington Grange			100110778426		
+LF	HMP Lancaster Farms			200001339049		
+LE	HMP Leeds			72079826		
+LC	HMP Leicester			2465057785		
+LW	HMP/YOI Lewes			100062273779		
+LY	HMP Leyhill			582486		
+LI	HMP/YOI Lincoln			235033467		
+LH	HMP Lindholme			10006712272		
+LT	HMP Littlehey			10000161141		
+LP	HMP Liverpool			38079136		
+LL	HMP Long Lartin			10013943723		
+LN	HMP/YOI Low Newton			100110739224		
+LG	HMP Lowdham Grange		company:03154430	10008170171		
+MS	HMP Maidstone (FNP)			200003717305		
+MR	HMP/YOI Manchester			77232134		
+MD	HMP/YOI Moorland			100051984633		
+MH	HMIRC Morton Hall (IRC)			10006531346		
+NH	HMP/YOI New Hall			63141057		
+NS	HMP North Sea Camp			100032166609		
+NL	HMP Northumberland		company:00842846	10024651947		
+NW	HMP/YOI Norwich			10009434824		
+NM	HMP/YOI Nottingham			200001412499		
+OW	HMP Oakwood		company:00390328	10090090220		
+ON	HMP Onley			28013722		
+PR	HMP/YOI Parc (YP)		company:03045222	200002656535		
+PV	HMP/YOI Pentonville			5300014341		
+PB	HMP/YOI Peterborough (F)		company:04350276	10008051379		
+PD	HMP/YOI Portland			10070567623		
+PN	HMP/YOI Preston			100012746893		
+RN	HMP Ranby			10013978351		
+RS	HMP Risley			100012381987		
+RC	HMP/YOI Rochester			44010823		
+RH	HMP Rye Hill		company:03682678	28042679		
+SD	HMP/YOI Send			10007066161		
+SF	HMP Stafford			200001335547		
+EH	HMP Standford Hill			200002533135		
+SK	HMP Stocken			10008626900		
+SH	HMP/YOI Stoke Heath			10013133936		
+ST	HMP/YOI Styal			100012881776		
+SU	HMP Sudbury			10070076922		
+SL	HMP Swaleside			100062087838		
+SW	HMP/YOI Swansea			100100986762		
+SN	HMP/YOI Swinfen Hall			10013212207		
+TS	HMP/YOI Thameside		company:07279250	10010227695		
+MT	HMP The Mount			200004050582		
+VE	HMIRC The Verne (IRC)			10070565745		
+TC	HMP/YOI Thorn Cross			200000978972		
+UK	HMP Usk and HMP/YOI Prescoed			200000955803		
+WD	HMP Wakefield			63131104		
+WW	HMP/YOI Wandsworth			121050999		
+WI	HMP/YOI Warren Hill			10008620969		
+WL	HMP Wayland			10011970324		
+WE	HMP Wealstun			72384891		
+WN	HMYOI Werrington			200001581565		
+WY	HMYOI Wetherby			72555064		
+WT	HMP Whatton			3040053432		
+WR	HMP Whitemoor			100091516265		
+WC	HMP/YOI Winchester			100062015988		
+WH	HMP/YOI Woodhill			25006001		
+WS	HMP/YOI Wormwood Scrubs			34020469		
+WM	HMP/YOI Wymott			200004064883		
+AK	HMP Acklington			2920005642		2011-10-31
+AL	HMP Albany			10003332444		2009-04
+AW	HMP Ashwell			100030715098		2011
+BT	HMP Blakenhurst			100121267009		2008-06-25
+BD	HMP Blundeston			100091568382		2013-12
+BK	HMP Brockhill			100120586678		2008-06-25
+BU	HMP Bullwood Hall			200000266767		2013-03-28
+CH	HMP Camp Hill			10003316343		2009-04
+CY	HMP Canterbury					2013-03-31
+CS	HMP Castington			2920009030		2011-10-31
+DR	HMP Dorchester					2013-12
+DV	HMIRC Dover			10034883299		2015
+NE	HMP Edmunds Hill			10023127022		2011-04
+EV	HMP Everthorpe			200000644359		2014-04
+GL	HMP Gloucester			200004486808		2013
+HR	HMIRC Haslar			37032487		2015
+HG	HMP Hewell Grange					2008-06-25
+HY	HMP Holloway			5300071065		2016-07
+PT	HMP Kingston			1775056170		2013-03-28
+LM	HMP Latchmere House					2011-09
+LA	HMP Lancaster					2011
+NN	HMP Northallerton			100050366776		2013-12
+PK	HMP Parkhurst			10003332443		2009-04
+RD	HMP Reading					2013-11
+SM	HMP Shepton Mallet			250022303		2013-02-28
+SY	HMP Shrewsbury			100071531042		2013-03
+WA	HMP The Weare			10070569459		2006
+WB	HMP Wellingborough			10023681392		2012-12-21
+WO	HMP Wolds					2014-04

--- a/lists/addresses/lib/prison_data.rb
+++ b/lists/addresses/lib/prison_data.rb
@@ -27,8 +27,8 @@ prisons.sort_by{|p| Matcher.massage_name(p.prison)}.each do |prison|
   company_number = Matcher.company_number(short_name, contracted_out)
   puts [
     code,
-    short_name,
     official_name,
+    nil,
     company_number,
     address,
     nil,
@@ -41,8 +41,8 @@ former_prisons.each do |prison|
   code = prison.prison
   puts [
     code,
-    prison.name,
     prison.official_name,
+    nil,
     nil,
     address,
     nil,


### PR DESCRIPTION
Leave `official-name` field blank. Todo, remove `official-name` from register later.