### PR TITLE
Various prison code maps file improvements

### DIFF
--- a/lists/addresses/lib/address_data_map.rb
+++ b/lists/addresses/lib/address_data_map.rb
@@ -12,7 +12,7 @@ addresses = LoadData.addresses ; nil
 
 puts %w[prison address].join("\t")
 prisons.each do |prison|
-  name = prison.prison
+  name = prison.name
   address = Matcher.address_uprn(name, prison, addresses)
   all_addresses = Matcher.all_addresses(prison, prisons, addresses, jointly_managed_prison_second_location)
   code = Matcher.match_code(name, codes)

--- a/lists/addresses/lib/address_street_postcode_data_map.rb
+++ b/lists/addresses/lib/address_street_postcode_data_map.rb
@@ -8,15 +8,18 @@ codes = LoadData.laa_codes ; nil
 prisons = LoadData.prison_finder_prisons ; nil
 former_prisons = LoadData.former_prisons ; nil
 addresses = LoadData.addresses ; nil
+official_names = LoadData.prison_map_prisons ; nil
 
-puts (%w[prison prison-name address] + addresses.first.morph_attributes.keys).join("\t")
+puts (%w[prison prison-name prison-short-name address] + addresses.first.morph_attributes.keys).join("\t")
 prisons.each do |prison|
   name = prison.prison
   address = Matcher.address_uprn(name, prison, addresses)
   code = Matcher.match_code(name, codes)
+  official_name = Matcher.match_official_name(name, official_names)
   short_name = Matcher.short_name(name)
   puts ([
     code,
+    official_name,
     short_name,
     address
   ] + addresses.detect{|a| a.key == address}.morph_attributes.values ).join("\t") if address
@@ -24,9 +27,11 @@ end
 former_prisons.each do |prison|
   address = Matcher.address_uprn(prison.name, prison, addresses)
   code = prison.prison
+  official_name = Matcher.match_official_name(prison.name, official_names)
   short_name = Matcher.short_name(prison.name)
   puts ([
     code,
+    official_name,
     short_name,
     address
   ] + addresses.detect{|a| a.key == address}.morph_attributes.values ).join("\t") if address

--- a/lists/addresses/lib/address_street_postcode_data_map.rb
+++ b/lists/addresses/lib/address_street_postcode_data_map.rb
@@ -12,7 +12,7 @@ official_names = LoadData.prison_map_prisons ; nil
 
 puts (%w[prison prison-name prison-short-name address] + addresses.first.morph_attributes.keys).join("\t")
 prisons.each do |prison|
-  name = prison.prison
+  name = prison.name
   address = Matcher.address_uprn(name, prison, addresses)
   code = Matcher.match_code(name, codes)
   official_name = Matcher.match_official_name(name, official_names)

--- a/lists/addresses/lib/load_data.rb
+++ b/lists/addresses/lib/load_data.rb
@@ -11,13 +11,13 @@ module LoadData
 
     def remove_jointly_managed prisons
       prisons.reject do |prison|
-        ['Usk/Prescoed (Prescoed)','Spring Hill'].include?(prison.prison)
+        ['Usk/Prescoed (Prescoed)','Spring Hill'].include?(prison.name)
       end
     end
 
     def remove_closed_prisons prisons
       prisons.reject do |prison|
-        ['Haslar Immigration Removal Centre','Dover Immigration Removal Centre'].include?(prison.prison)
+        ['Haslar Immigration Removal Centre','Dover Immigration Removal Centre'].include?(prison.name)
       end
     end
 
@@ -66,7 +66,7 @@ module LoadData
     def jointly_managed_prison_second_location
       prisons = Morph.from_tsv read('../../prison-finder/prison-address-text.tsv'), :prison
       prisons.select do |prison|
-        ['Usk/Prescoed (Prescoed)','Spring Hill'].include?(prison.prison)
+        ['Usk/Prescoed (Prescoed)','Spring Hill'].include?(prison.name)
       end
     end
 

--- a/lists/addresses/lib/matcher.rb
+++ b/lists/addresses/lib/matcher.rb
@@ -163,9 +163,9 @@ module Matcher
     end
 
     def contracted_code location, prisons, codes
-      prison = prisons.detect{|x| massage_name(short_name(x.prison)) == location}
+      prison = prisons.detect{|x| massage_name(short_name(x.name)) == location}
       if prison
-        short_name = short_name(prison.prison)
+        short_name = short_name(prison.name)
         match_code(short_name, codes)
       end
     end
@@ -178,14 +178,14 @@ module Matcher
     end
 
     def other_addresses other_location, address, prisons, addresses
-      prison = prisons.detect{|x| x.prison == other_location}
+      prison = prisons.detect{|x| x.name == other_location}
       binding.pry if prison.nil?
-      [address, address_uprn(prison.prison, prison, addresses)]
+      [address, address_uprn(prison.name, prison, addresses)]
     end
 
     def all_addresses prison, prisons, addresses, jointly_managed_prison_second_location
-      address = address_uprn(prison.prison, prison, addresses)
-      case prison.prison
+      address = address_uprn(prison.name, prison, addresses)
+      case prison.name
       when 'Usk/Prescoed (Usk)'
         other_addresses('Usk/Prescoed (Prescoed)', address, jointly_managed_prison_second_location, addresses).join(";")
       when 'Grendon'

--- a/lists/addresses/lib/nomis_code_map.rb
+++ b/lists/addresses/lib/nomis_code_map.rb
@@ -10,10 +10,10 @@ prisons = LoadData.prison_finder_prisons ; nil
 puts %w[nomis prison name].join("\t")
 nomis_codes.each do |n|
   prison = prisons.detect do |p|
-    n.nomis == Matcher.match_nomis_code(Matcher.short_name(p.prison), nomis_codes)
+    n.nomis == Matcher.match_nomis_code(Matcher.short_name(p.name), nomis_codes)
   end
   code = if prison
-           name = prison.prison
+           name = prison.name
            short_name = Matcher.short_name(name)
            Matcher.match_code(short_name, codes)
          else

--- a/lists/addresses/lib/nomis_code_map.rb
+++ b/lists/addresses/lib/nomis_code_map.rb
@@ -6,15 +6,18 @@ require_relative 'matcher'
 codes = LoadData.laa_codes ; nil
 nomis_codes = LoadData.nomis_codes ; nil
 prisons = LoadData.prison_finder_prisons ; nil
+former_prisons = LoadData.former_prisons ; nil
 
 puts %w[nomis prison name].join("\t")
 nomis_codes.each do |n|
   prison = prisons.detect do |p|
     n.nomis == Matcher.match_nomis_code(Matcher.short_name(p.name), nomis_codes)
   end
+  prison = former_prisons.detect do |p|
+    n.nomis == Matcher.match_nomis_code(Matcher.short_name(p.name), nomis_codes)
+  end unless prison
   code = if prison
-           name = prison.name
-           short_name = Matcher.short_name(name)
+           short_name = Matcher.short_name(prison.name)
            Matcher.match_code(short_name, codes)
          else
            nil

--- a/lists/addresses/lib/prison_data.rb
+++ b/lists/addresses/lib/prison_data.rb
@@ -16,8 +16,8 @@ addresses = LoadData.addresses ; nil
 
 puts %w[prison name official-name organisation address start-date end-date].join("\t")
 
-prisons.sort_by{|p| Matcher.massage_name(p.prison)}.each do |prison|
-  name = prison.prison
+prisons.sort_by{|p| Matcher.massage_name(p.name)}.each do |prison|
+  name = prison.name
   address = Matcher.address_uprn(name, prison, addresses)
   official_name = Matcher.match_official_name(name, official_names)
   short_name = Matcher.short_name(name)
@@ -38,7 +38,7 @@ end
 
 former_prisons.each do |prison|
   address = Matcher.address_uprn(prison.name, prison, addresses)
-  code = prison.prison
+  code = prison.name
   puts [
     code,
     prison.official_name,

--- a/lists/addresses/lib/write_data.rb
+++ b/lists/addresses/lib/write_data.rb
@@ -17,7 +17,7 @@ module WriteData
 
     def print_match_html prison, match
       puts '<tr style="margin-top: 2em;">'
-      puts '<td style="vertical-align: top">' + prison.prison + '</td>'
+      puts '<td style="vertical-align: top">' + prison.name + '</td>'
       puts '<td style="vertical-align: top">' + prison.to_s("<br/>") + '</td>'
       if match[0] && match[1] > 2.4
         puts '<td style="vertical-align: top">' + match[0].to_s("<br/>") + '</td>'
@@ -34,7 +34,7 @@ module WriteData
     def print_matches_html prisons, addresses
       puts '<html><body style="font-family: sans-serif;"><table style="border-spacing:2em;">'
       prisons.sort_by do |x|
-        Matcher.match_address(x, addresses)[1].to_s + x.prison
+        Matcher.match_address(x, addresses)[1].to_s + x.name
       end.each do |x|
         WriteData.print_match_html x, match_address(prison, addresses)
       end

--- a/lists/prison-finder/bin/scrape_address.rb
+++ b/lists/prison-finder/bin/scrape_address.rb
@@ -37,10 +37,10 @@ def address_postcode name, doc
         map(&:strip).
         map{|w| w.chomp(",")}.
         map(&:strip).
-        delete_if do |w| 
+        delete_if do |w|
           opc = $pc
           $pc = w[/[0-9][A-Z][A-Z]/].to_s.size > 0 unless $pc
-          opc || w.size == 0 
+          opc || w.size == 0
         end
   end.first
   address = address.first.split(",") if address && address.size == 1
@@ -86,7 +86,7 @@ def ignore? name
   name == 'Usk'
 end
 
-puts "prison\taddress-text\tpostcode"
+puts "name\taddress-text\tpostcode"
 name_address_postcodes.
   reject{|name, a, p| ignore?(name)}.
   sort_by{|name, a, p| name}.

--- a/lists/prison-finder/prison-address-text.tsv
+++ b/lists/prison-finder/prison-address-text.tsv
@@ -1,4 +1,4 @@
-prison	address-text	postcode
+name	address-text	postcode
 Altcourse	Higher Lane|Fazakerley|Liverpool	L9 7LH
 Ashfield	Shortwood Road|Pucklechurch|Bristol	BS16 9QJ
 Askham Grange	Askham Richard|York	YO23 3FT

--- a/maps/index.yml
+++ b/maps/index.yml
@@ -2,7 +2,7 @@
 prison:
   description: Prison in prison register
   key: prison
-noms-spend-data:
+contracted-out:
   description: Prison name in NOMS spend data over £25,000 files
   key: contracted-out
 nomis-code:

--- a/maps/nomis-code.tsv
+++ b/maps/nomis-code.tsv
@@ -26,7 +26,7 @@ DHI	DH	DRAKE HALL (HMP & YOI)
 DMI	DM	DURHAM (HMP)
 DNI	DN	DONCASTER (HMP)
 DTI	DT	DEERBOLT (HMPYOI)
-DVI		Dover Immigration Removal Centre
+DVI	DV	Dover Immigration Removal Centre
 DWI	DW	DOWNVIEW (HMP)
 EEI	EE	ERLESTOKE (HMP)
 EHI	EH	STANDFORD HILL (HMP)
@@ -56,7 +56,7 @@ HLI	HL	HULL (HMP)
 HMI	HM	HUMBER (HMP)
 HOI	HO	HIGH DOWN (HMP)
 HPI	HP	HIGHPOINT (HMP)
-HRI		Haslar Immigration Removal Centre
+HRI	HR	Haslar Immigration Removal Centre
 HVI	HV	HAVERIGG (HMP)
 ISI	IS	ISIS HMP/YOI
 IWI	PK	ISLE OF WIGHT (HMP)
@@ -127,30 +127,30 @@ WSI	WS	WORMWOOD SCRUBS (HMP)
 WTI	WT	WHATTON (HMP)
 WWI	WW	WANDSWORTH (HMP)
 WYI	WY	WETHERBY (HMPYOI)
-AKI		Acklington
-ALI		Albany
-AWI		Ashwell
+AKI	AK	Acklington
+ALI	AL	Albany
+AWI	AW	Ashwell
 BTI		Blakenhurst
-BDI		Blundeston
+BDI	BD	Blundeston
 BKI		Brockhill
-BUI		Bullwood Hall
-CHI		Camp Hill
-CYI		Canterbury
+BUI	BU	Bullwood Hall
+CHI	CH	Camp Hill
+CYI	CY	Canterbury
 CSI		Castinglon
-DRI		Dorchester
-NEI		Edmunds Hill
-EVI		Everthorpe
-GLI		Gloucester
+DRI	DR	Dorchester
+NEI	NE	Edmunds Hill
+EVI	EV	Everthorpe
+GLI	GL	Gloucester
 HGI		Hewell Grange
-HYI		Holloway
-PTI		Kingston
-LMI		Latchmere House
+HYI	HY	Holloway
+PTI	PT	Kingston
+LMI	LM	Latchmere House
 LAI		Lancaster
-NNI		Northallerton
-PKI		Parkhurst
-RDI		Reading
-SMI		Shepton Mallet
-SYI		Shrewsbury
+NNI	NN	Northallerton
+PKI	PK	Parkhurst
+RDI	RD	Reading
+SMI	SM	Shepton Mallet
+SYI	SY	Shrewsbury
 WAI		The Weare
-WBI		Wellingborough
-WOI		Wolds
+WBI	WB	Wellingborough
+WOI	WO	Wolds


### PR DESCRIPTION
* Add former prison codes to maps/nomis-codes.tsv
* Add longer prison name to address maps file.
* Rename "prison" to "name" in prison finder data file and scripts.
* Fix maps index key to match filename.